### PR TITLE
Use the correct history /ping setup in setup

### DIFF
--- a/brewblox_ctl_lib/setup_command.py
+++ b/brewblox_ctl_lib/setup_command.py
@@ -120,7 +120,7 @@ def config_datastore():
 def config_history():
     url = lib_utils.get_history_url()
     return [
-        '{} http wait {}/_service/status'.format(const.CLI, url),
+        '{} http wait {}/ping'.format(const.CLI, url),
         '{} http post {}/query/configure'.format(const.CLI, url),
     ]
 


### PR DESCRIPTION
_service/status only checks the python service, not influx.
Usually checking _service/status works because datastore is configured first, giving influx some more time start.

/ping should be used instead, as it actually pings the influx service.