### PR TITLE
Add name to network bridge in compose

### DIFF
--- a/brewblox_ctl_lib/data/amd64/docker-compose.shared.yml
+++ b/brewblox_ctl_lib/data/amd64/docker-compose.shared.yml
@@ -69,3 +69,9 @@ services:
     labels:
       - "traefik.port=80"
       - "traefik.frontend.rule=Path:/, /ui, /ui/{sub:(.*)?}"
+
+networks:
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.bridge.name: brewblox_bridge

--- a/brewblox_ctl_lib/data/armhf/docker-compose.shared.yml
+++ b/brewblox_ctl_lib/data/armhf/docker-compose.shared.yml
@@ -69,3 +69,9 @@ services:
     labels:
       - "traefik.port=80"
       - "traefik.frontend.rule=Path:/, /ui, /ui/{sub:(.*)?}"
+
+networks:
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.bridge.name: brewblox_bridge


### PR DESCRIPTION
With a named network bridge, logs are more readable (dmesg for example).
It is also now possible to let the ubuntu network manager ignore it:

Example /etc/NetworkManager/NetworkManager.conf
```
[main]
plugins=ifupdown,keyfile
[ifupdown]
managed=false
[device]
wifi.scan-rand-mac-address=no
[keyfile]
unmanaged-devices=interface-name:docker0;interface-name:veth*;interface-name:brewblox*
```