### PR TITLE
Revert "add name to network bridge in compose"

### DIFF
--- a/brewblox_ctl_lib/data/amd64/docker-compose.shared.yml
+++ b/brewblox_ctl_lib/data/amd64/docker-compose.shared.yml
@@ -69,9 +69,3 @@ services:
     labels:
       - "traefik.port=80"
       - "traefik.frontend.rule=Path:/, /ui, /ui/{sub:(.*)?}"
-
-networks:
-  default:
-    driver: bridge
-    driver_opts:
-      com.docker.network.bridge.name: brewblox_bridge

--- a/brewblox_ctl_lib/data/armhf/docker-compose.shared.yml
+++ b/brewblox_ctl_lib/data/armhf/docker-compose.shared.yml
@@ -69,9 +69,3 @@ services:
     labels:
       - "traefik.port=80"
       - "traefik.frontend.rule=Path:/, /ui, /ui/{sub:(.*)?}"
-
-networks:
-  default:
-    driver: bridge
-    driver_opts:
-      com.docker.network.bridge.name: brewblox_bridge


### PR DESCRIPTION
On a Synology NAS, giving the bridge interface a name caused the network to stop working.
Maybe their docker stack uses works differently and can't handle the custom name.

Reverting the change.